### PR TITLE
Add warning message for s3api command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Before deployment, you should uplad zipped code files to s3 like this:
 (.venv) $ aws s3api create-bucket --bucket <i>your-s3-bucket-name-for-lambda-layer-code</i> --region <i>region-name</i>
 (.venv) $ ./build-aws-lambda-layer-package.sh <i>your-s3-bucket-name-for-lambda-layer-code</i>
 </pre>
+(:warning: Regions outside of `us-east-1` require the appropriate LocationConstraint to be specified in order to create the bucket in the desired region. For more information, check this [docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/create-bucket.html#examples))
 (:warning: Make sure you have **Docker** installed.)
 
 For example,


### PR DESCRIPTION
*Description of changes:*

- While testing with `ap-northeast-2` region, the s3api aws-cli command does not work, so I add it.
- Ref: aws.s3api [create-bucket](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/create-bucket.html)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
